### PR TITLE
Use dedicated control topic per Iceberg sink (#3)

### DIFF
--- a/billing/data-product/debezium/iceberg-sink.json
+++ b/billing/data-product/debezium/iceberg-sink.json
@@ -17,6 +17,7 @@
     "iceberg.tables": "billing_raw.billing_events",
     "iceberg.tables.auto-create-enabled": "true",
     "iceberg.tables.evolve-schema-enabled": "true",
+    "iceberg.control.topic": "control-iceberg-billing",
     "iceberg.control.commit.interval-ms": "10000",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/claims/data-product/debezium/iceberg-sink.json
+++ b/claims/data-product/debezium/iceberg-sink.json
@@ -17,6 +17,7 @@
     "iceberg.tables": "claims_raw.claims_events",
     "iceberg.tables.auto-create-enabled": "true",
     "iceberg.tables.evolve-schema-enabled": "true",
+    "iceberg.control.topic": "control-iceberg-claims",
     "iceberg.control.commit.interval-ms": "10000",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/hr-system/data-product/debezium/iceberg-sink-employee.json
+++ b/hr-system/data-product/debezium/iceberg-sink-employee.json
@@ -17,6 +17,7 @@
         "iceberg.tables": "hr_raw.employee_events",
         "iceberg.tables.auto-create-enabled": "true",
         "iceberg.tables.evolve-schema-enabled": "true",
+        "iceberg.control.topic": "control-iceberg-hr-employee",
         "iceberg.control.commit.interval-ms": "10000",
         "key.converter": "org.apache.kafka.connect.storage.StringConverter",
         "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/hr-system/data-product/debezium/iceberg-sink-orgunit.json
+++ b/hr-system/data-product/debezium/iceberg-sink-orgunit.json
@@ -17,6 +17,7 @@
         "iceberg.tables": "hr_raw.org_unit_events",
         "iceberg.tables.auto-create-enabled": "true",
         "iceberg.tables.evolve-schema-enabled": "true",
+        "iceberg.control.topic": "control-iceberg-hr-orgunit",
         "iceberg.control.commit.interval-ms": "10000",
         "key.converter": "org.apache.kafka.connect.storage.StringConverter",
         "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/partner/data-product/debezium/iceberg-sink.json
+++ b/partner/data-product/debezium/iceberg-sink.json
@@ -17,6 +17,7 @@
     "iceberg.tables": "partner_raw.person_events",
     "iceberg.tables.auto-create-enabled": "true",
     "iceberg.tables.evolve-schema-enabled": "true",
+    "iceberg.control.topic": "control-iceberg-partner",
     "iceberg.control.commit.interval-ms": "10000",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/policy/data-product/debezium/iceberg-sink.json
+++ b/policy/data-product/debezium/iceberg-sink.json
@@ -17,6 +17,7 @@
     "iceberg.tables": "policy_raw.policy_events",
     "iceberg.tables.auto-create-enabled": "true",
     "iceberg.tables.evolve-schema-enabled": "true",
+    "iceberg.control.topic": "control-iceberg-policy",
     "iceberg.control.commit.interval-ms": "10000",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/product/data-product/debezium/iceberg-sink.json
+++ b/product/data-product/debezium/iceberg-sink.json
@@ -17,6 +17,7 @@
     "iceberg.tables": "product_raw.product_events",
     "iceberg.tables.auto-create-enabled": "true",
     "iceberg.tables.evolve-schema-enabled": "true",
+    "iceberg.control.topic": "control-iceberg-product",
     "iceberg.control.commit.interval-ms": "10000",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",


### PR DESCRIPTION
## Summary
- Sets explicit `iceberg.control.topic: control-iceberg-{domain}` on all 7 Iceberg sink connectors (partner, policy, billing, claims, product, hr-employee, hr-orgunit) instead of sharing the default `control-iceberg` topic
- Removes the race condition on `control-iceberg-0` where parallel coordinators dropped each other's `DATA_WRITTEN` responses, leaving sinks committing to 0 tables
- Addresses Problem 2 from `arch-problem.md`

Closes #3

## Test plan
- [x] JSON syntax of all 7 sink configs validated
- [x] Connect API `/connector-plugins/IcebergSinkConnector/config/validate` returns no errors for all 7 configs; reports the new `iceberg.control.topic` value per sink
- [ ] Re-deploy live sinks (delete + recreate, plus consumer-group cleanup per #7) and verify each `control-iceberg-{domain}` topic appears in Kafka and sinks commit to their tables