### PR TITLE
Nessie-Catalog auf persistenten Storage umstellen (IN_MEMORY → ROCKSDB)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -923,8 +923,11 @@ services:
     ports:
       - "19120:19120"
     environment:
-      NESSIE_VERSION_STORE_TYPE: IN_MEMORY
+      NESSIE_VERSION_STORE_TYPE: ROCKSDB
+      NESSIE_VERSION_STORE_PERSIST_ROCKS_DATABASE_PATH: /nessie/data
       QUARKUS_OTEL_ENABLED: "false"
+    volumes:
+      - nessie-data:/nessie/data
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:19120/api/v2/config || exit 1"]
       interval: 10s
@@ -1402,6 +1405,7 @@ volumes:
   billing-db-data:
   hr-db-data:
   minio-data:
+  nessie-data:
   superset-db-data:
   openmetadata-db-data:
   openmetadata-esdata:


### PR DESCRIPTION
Closes #2

## Summary

- Nessie im Compose-Stack von `IN_MEMORY` auf `ROCKSDB` mit persistentem Volume umgestellt, damit der Iceberg-Catalog Container-Restarts überlebt.
- Neues benanntes Volume `nessie-data` gemounted nach `/nessie/data`; Pfad via `NESSIE_VERSION_STORE_PERSIST_ROCKS_DATABASE_PATH` konfiguriert (gemäss Nessie-Doku).
- Kein Impact auf Domain-Code, Kafka-Topics, ODCs, SQLMesh-Modelle oder K8s-Manifest (K8s nutzt bereits JDBC/Postgres).

## Verification

- [x] `podman compose config` valide
- [x] `podman compose up -d nessie` startet healthy, RocksDB-Files (`CURRENT`, `MANIFEST-*`, `LOG`, `*.log`) in `/nessie/data` vorhanden
- [x] Restart-Test: `podman compose restart nessie` — `repositoryCreationTimestamp` bleibt identisch (keine Neuinitialisierung des Catalogs)

## Test plan

- [ ] `./deploy-compose.sh -d` (bzw. `./deploy.sh -d`) durchläuft end-to-end
- [ ] Nach erfolgreichem Bootstrap: `podman compose restart nessie` → Trino-Query auf `iceberg.partner_raw.partner` liefert weiterhin Daten

🤖 Generated with [Claude Code](https://claude.com/claude-code)