### PR TITLE
deploy.sh: Raw-Table-Prüfung validiert keine Daten (nur Metadata)

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -91,19 +91,13 @@ if [[ "$DAEMON_MODE" == true ]]; then
 
     echo ""
     echo "▶ Waiting for Debezium Iceberg sinks to commit raw data…"
-    for attempt in $(seq 1 60); do
-      # Check Nessie directly for raw table entries
-      NESSIE_TABLES=$(curl -sf "http://localhost:19120/api/v2/trees/main/entries" 2>/dev/null \
-        | python3 -c "import sys,json; d=json.load(sys.stdin); print(sum(1 for e in d.get('entries',[]) if e['type']=='ICEBERG_TABLE' and '_raw.' in '.'.join(e['name']['elements'])))" 2>/dev/null || echo "0")
-      if [[ "${NESSIE_TABLES}" -ge 5 ]] 2>/dev/null; then
-        echo "  ✓ Raw tables committed to Nessie (${NESSIE_TABLES} tables)"
-        # Give sinks a few more seconds to flush remaining data
-        sleep 10
-        break
-      fi
-      echo "  Waiting… (${NESSIE_TABLES}/5 raw tables in Nessie, attempt $attempt/60)"
-      sleep 5
-    done
+    if ! scripts/check-raw-tables.sh; then
+      echo "  ✗ Aborting: raw tables have no data — transform-init would build empty Silver/Gold." >&2
+      echo "    Inspect Kafka Connect logs and iceberg-sink connector status before retrying." >&2
+      exit 1
+    fi
+    # Give sinks a few more seconds to flush remaining data
+    sleep 10
 
     echo ""
     echo "▶ Running Silver/Gold transformations (Iceberg → Trino)..."

--- a/scripts/check-raw-tables.sh
+++ b/scripts/check-raw-tables.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# check-raw-tables.sh – Verify that all Iceberg raw tables contain data.
+#
+# Queries Trino via its HTTP statement API and waits until every raw table
+# reports count(*) > 0, or exits non-zero on timeout. Replaces the previous
+# Nessie-metadata-only check in deploy.sh, which passed even when sinks had
+# auto-created empty tables without writing data (issue #4).
+set -euo pipefail
+
+TRINO_URL="${TRINO_URL:-http://localhost:8086}"
+MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-300}"
+SLEEP_SECONDS="${SLEEP_SECONDS:-5}"
+
+RAW_TABLES=(
+  "partner_raw.person_events"
+  "product_raw.product_events"
+  "policy_raw.policy_events"
+  "billing_raw.billing_events"
+  "claims_raw.claims_events"
+  "hr_raw.employee_events"
+  "hr_raw.org_unit_events"
+)
+
+# trino_count <fully-qualified-table>
+# Prints the row count on stdout, or "-1" on any error (unreachable, table
+# missing, Trino error). Silent – callers format their own output.
+trino_count() {
+  local table="$1"
+  local sql="SELECT count(*) FROM iceberg.${table}"
+  python3 - "$TRINO_URL" "$sql" <<'PY' 2>/dev/null || echo "-1"
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+trino_url, sql = sys.argv[1], sys.argv[2]
+req = urllib.request.Request(
+    f"{trino_url}/v1/statement",
+    data=sql.encode("utf-8"),
+    headers={"X-Trino-User": "deploy-check"},
+)
+try:
+    resp = urllib.request.urlopen(req, timeout=10)
+except urllib.error.URLError:
+    print(-1)
+    sys.exit(0)
+
+body = json.loads(resp.read())
+if body.get("error"):
+    print(-1)
+    sys.exit(0)
+
+next_uri = body.get("nextUri")
+result = body.get("data")
+while next_uri:
+    time.sleep(0.3)
+    try:
+        resp = urllib.request.urlopen(next_uri, timeout=10)
+    except urllib.error.URLError:
+        print(-1)
+        sys.exit(0)
+    body = json.loads(resp.read())
+    if body.get("error", {}).get("message"):
+        print(-1)
+        sys.exit(0)
+    if body.get("data"):
+        result = body["data"]
+    next_uri = body.get("nextUri")
+
+try:
+    print(int(result[0][0]))
+except (TypeError, ValueError, IndexError):
+    print(-1)
+PY
+}
+
+echo "▶ Verifying raw-table row counts via Trino (${TRINO_URL})…"
+
+elapsed=0
+while (( elapsed < MAX_WAIT_SECONDS )); do
+  populated=0
+  summary=""
+  for table in "${RAW_TABLES[@]}"; do
+    count="$(trino_count "$table")"
+    summary+="${table}=${count} "
+    if [[ "$count" =~ ^[0-9]+$ ]] && (( count > 0 )); then
+      populated=$(( populated + 1 ))
+    fi
+  done
+
+  if (( populated == ${#RAW_TABLES[@]} )); then
+    echo "  ✓ Raw tables have data (${populated}/${#RAW_TABLES[@]}: ${summary% })"
+    exit 0
+  fi
+
+  echo "  Waiting… (${populated}/${#RAW_TABLES[@]} raw tables populated, ${elapsed}s/${MAX_WAIT_SECONDS}s)"
+  sleep "$SLEEP_SECONDS"
+  elapsed=$(( elapsed + SLEEP_SECONDS ))
+done
+
+echo "  ✗ Timeout: raw tables still empty or unreachable after ${MAX_WAIT_SECONDS}s" >&2
+echo "    Last seen: ${summary% }" >&2
+exit 1


### PR DESCRIPTION
Closes #4

## Summary
- Replace Nessie metadata-only check in `deploy.sh` with a Trino-backed row-count probe so deploys no longer pass when raw tables exist but are empty.
- Add `scripts/check-raw-tables.sh` that polls Trino's `/v1/statement` API for all seven raw tables (`partner_raw.person_events`, `product_raw.product_events`, `policy_raw.policy_events`, `billing_raw.billing_events`, `claims_raw.claims_events`, `hr_raw.employee_events`, `hr_raw.org_unit_events`) and exits non-zero on timeout.
- `deploy.sh` now aborts with a clear error instead of silently running `transform-init` against empty raw data.

## Notes
- No Maven modules, domain code, Kafka events, ODC contracts or SQLMesh models were touched — pure infra/scripts fix.
- Config via env vars: `TRINO_URL` (default `http://localhost:8086`), `MAX_WAIT_SECONDS` (default `300`), `SLEEP_SECONDS` (default `5`).

## Test plan
- [x] Fail-path smoke test (`MAX_WAIT_SECONDS=15 scripts/check-raw-tables.sh` against a stack without raw data → exit 1 with summary of per-table counts)
- [x] `./build.sh` green (full Maven + container images)
- [ ] Happy-path smoke test: `./deploy.sh --test-data -d` on a fresh stack reports `✓ Raw tables have data (7/7, …)` and Superset dashboards populate
- [ ] Fail-path smoke test without seed data: deploy aborts before `transform-init` runs