### PR TITLE
transform-init.py: Container-DNS über Environment-Variablen konfigurierbar machen

### DIFF
--- a/infra/trino/transform-init.py
+++ b/infra/trino/transform-init.py
@@ -11,7 +11,8 @@ import time
 import urllib.request
 import urllib.error
 
-TRINO = "http://trino:8086"
+TRINO = os.environ.get("TRINO_URL", "http://trino:8086")
+NESSIE = os.environ.get("NESSIE_URL", "http://nessie:19120")
 
 
 def trino_exec(sql: str, quiet: bool = False) -> int | None:
@@ -76,7 +77,7 @@ def create_table(name: str, sql: str):
 def has_raw_table(schema: str) -> bool:
     """Check if an Iceberg raw schema exists in Nessie."""
     try:
-        req = urllib.request.Request("http://nessie:19120/api/v2/trees/main/entries")
+        req = urllib.request.Request(f"{NESSIE}/api/v2/trees/main/entries")
         resp = urllib.request.urlopen(req)
         entries = json.loads(resp.read()).get("entries", [])
         for e in entries:


### PR DESCRIPTION
Closes #5

## Summary
- `TRINO_URL` und `NESSIE_URL` werden als optionale ENV-Variablen gelesen, mit den bisherigen Compose-DNS-Werten (`http://trino:8086`, `http://nessie:19120`) als Default.
- Script bleibt im Compose-Netzwerk unverändert lauffähig; Debug-Läufe vom Host gehen jetzt ohne Text-Patching.

## Test plan
- [x] `python3 -m py_compile infra/trino/transform-init.py`
- [ ] Compose-Run (`deploy.sh` bzw. `compose run --rm transform-init`) weiterhin grün — Defaults greifen
- [ ] Ad-hoc-Run vom Host mit `TRINO_URL=http://localhost:8086 NESSIE_URL=http://localhost:19120 python3 infra/trino/transform-init.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)