### PR TITLE
deploy.sh: transform-init nicht via 'compose run' ausführen (recreiert Dependencies)

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -101,7 +101,7 @@ if [[ "$DAEMON_MODE" == true ]]; then
 
     echo ""
     echo "▶ Running Silver/Gold transformations (Iceberg → Trino)..."
-    ${=COMPOSE_CMD} run --rm transform-init
+    ${=COMPOSE_CMD} run --rm --no-deps transform-init
   fi
 
   echo ""


### PR DESCRIPTION
Closes #6

## Zusammenfassung

`deploy.sh` rief die Silver/Gold-Transformationen am Ende des `--test-data`-Flows via
`${=COMPOSE_CMD} run --rm transform-init` auf. `compose run` startet per Default alle
`depends_on`-Container neu (Trino und transitive Dependencies: Nessie, MinIO, Vault) —
kombiniert mit Nessie IN_MEMORY zerstörte das den gerade aufgebauten Raw-Layer und ist
auch mit dem ROCKSDB-Fix (PR #9) unsauber.

## Änderung

- `deploy.sh:104`: `--no-deps` an `compose run --rm transform-init` ergänzt.

`--no-deps` existiert sowohl in `docker compose` als auch `podman compose` und verhindert
das Rekreieren der Abhängigkeiten. Zum Zeitpunkt des Aufrufs laufen Trino/Nessie/MinIO/Vault
bereits gesund (nach `compose up` + `check-raw-tables.sh`).

## Warum nicht Option (b) aus dem Issue

`podman exec datamesh-trino-1 python3 …` wurde verworfen: hardcoded Container-Name,
setzt Python im Trino-Image voraus, benötigt zusätzliches Volume-Mount.

## Scope

- Keine Domain-Services, keine Kafka-Topics/ODCs, keine SQLMesh-/Soda-/Debezium-Änderungen.
- Kein Tests-Impact — reine Flag-Ergänzung im Shell-Script; `bash -n` Syntax-Check grün.

## Test plan

- [ ] `./deploy-compose.sh -d --test-data --delete-volumes` durchlaufen lassen
- [ ] Container-IDs von `trino`, `nessie`, `minio`, `vault` vor/nach `▶ Running Silver/Gold transformations …` vergleichen — dürfen sich nicht ändern
- [ ] Silver/Gold-Tables in Trino verfügbar, Raw-Layer behält Daten