### PR TITLE
fix(hr-system): align silver eventtype filter with published events

### DIFF
--- a/hr-system/data-product/sqlmesh/silver/employee.sql
+++ b/hr-system/data-product/sqlmesh/silver/employee.sql
@@ -30,6 +30,7 @@ WITH ranked AS (
     FROM iceberg.hr_raw.employee_events
     WHERE employeeid IS NOT NULL
       AND employeeid != ''
+      AND (eventtype = 'employee.updated' OR eventtype IS NULL)
       AND from_iso8601_timestamp(timestamp) BETWEEN @start_date AND @end_date
 )
 

--- a/hr-system/data-product/sqlmesh/silver/org_unit.sql
+++ b/hr-system/data-product/sqlmesh/silver/org_unit.sql
@@ -26,7 +26,7 @@ WITH ranked AS (
     FROM iceberg.hr_raw.org_unit_events
     WHERE orgunitid IS NOT NULL
       AND name IS NOT NULL
-      AND eventtype IN ('OrgUnitState', 'OrgUnitChanged')
+      AND (eventtype = 'org-unit.updated' OR eventtype IS NULL)
       AND from_iso8601_timestamp(timestamp) BETWEEN @start_date AND @end_date
 )
 

--- a/infra/trino/transform-init.py
+++ b/infra/trino/transform-init.py
@@ -245,7 +245,9 @@ WITH ranked AS (
         COALESCE(active, true) AS active, COALESCE(deleted, false) AS deleted, version,
         from_iso8601_timestamp(timestamp) AS updated_at,
         ROW_NUMBER() OVER (PARTITION BY employeeid ORDER BY from_iso8601_timestamp(timestamp) DESC NULLS LAST, version DESC NULLS LAST) AS rn
-    FROM iceberg.hr_raw.employee_events WHERE employeeid IS NOT NULL AND employeeid != ''
+    FROM iceberg.hr_raw.employee_events
+    WHERE employeeid IS NOT NULL AND employeeid != ''
+      AND (eventtype = 'employee.updated' OR eventtype IS NULL)
 )
 SELECT employee_id, external_id, first_name, last_name,
     TRIM(COALESCE(first_name,'')||' '||COALESCE(last_name,'')) AS full_name,
@@ -262,7 +264,8 @@ WITH ranked AS (
         from_iso8601_timestamp(timestamp) AS updated_at,
         ROW_NUMBER() OVER (PARTITION BY orgunitid ORDER BY from_iso8601_timestamp(timestamp) DESC NULLS LAST, version DESC NULLS LAST) AS rn
     FROM iceberg.hr_raw.org_unit_events
-    WHERE orgunitid IS NOT NULL AND name IS NOT NULL AND eventtype IN ('OrgUnitState','OrgUnitChanged')
+    WHERE orgunitid IS NOT NULL AND name IS NOT NULL
+      AND (eventtype = 'org-unit.updated' OR eventtype IS NULL)
 )
 SELECT org_unit_id, external_id, name, parent_org_unit_id, level, active, deleted, updated_at
 FROM ranked WHERE rn = 1

--- a/infra/trino/transform-init.sh
+++ b/infra/trino/transform-init.sh
@@ -215,7 +215,9 @@ WITH ranked AS (
            COALESCE(active, true) AS active, COALESCE(deleted, false) AS deleted, version,
            from_iso8601_timestamp(timestamp) AS updated_at,
            ROW_NUMBER() OVER (PARTITION BY employeeid ORDER BY from_iso8601_timestamp(timestamp) DESC NULLS LAST, version DESC NULLS LAST) AS rn
-    FROM iceberg.hr_raw.employee_events WHERE employeeid IS NOT NULL AND employeeid != ''
+    FROM iceberg.hr_raw.employee_events
+    WHERE employeeid IS NOT NULL AND employeeid != ''
+      AND (eventtype = 'employee.updated' OR eventtype IS NULL)
 )
 SELECT employee_id, external_id, first_name, last_name,
        TRIM(COALESCE(first_name,'')||' '||COALESCE(last_name,'')) AS full_name,
@@ -233,7 +235,8 @@ WITH ranked AS (
            from_iso8601_timestamp(timestamp) AS updated_at,
            ROW_NUMBER() OVER (PARTITION BY orgunitid ORDER BY from_iso8601_timestamp(timestamp) DESC NULLS LAST, version DESC NULLS LAST) AS rn
     FROM iceberg.hr_raw.org_unit_events
-    WHERE orgunitid IS NOT NULL AND name IS NOT NULL AND eventtype IN ('OrgUnitState','OrgUnitChanged')
+    WHERE orgunitid IS NOT NULL AND name IS NOT NULL
+      AND (eventtype = 'org-unit.updated' OR eventtype IS NULL)
 )
 SELECT org_unit_id, external_id, name, parent_org_unit_id, level, active, deleted, updated_at
 FROM ranked WHERE rn = 1"


### PR DESCRIPTION
Closes #16

## Summary

`iceberg.hr_silver.org_unit` war leer (und damit auch `analytics.org_hierarchy`), weil das Silver-Filter auf `eventtype IN ('OrgUnitState','OrgUnitChanged')` filterte — Werte, die die HR-Integration nie publiziert.

Tatsächlich publizierte Eventtypes:
- `hr.v1.org-unit.changed` → `eventtype = 'org-unit.updated'`
- `hr.v1.org-unit.state` → kein `eventtype`-Feld (→ NULL in Iceberg)

## Changes

- **`hr-system/data-product/sqlmesh/silver/org_unit.sql`**: Filter auf `eventtype = 'org-unit.updated' OR eventtype IS NULL` gesetzt.
- **`hr-system/data-product/sqlmesh/silver/employee.sql`**: konsistenter Eventtype-Filter ergänzt. Lief bisher per Zufall grün, da Changed-Events keine state-Felder tragen und implizit rausflogen — jetzt explizit, schützt vor zukünftigen Regressionen.
- **`infra/trino/transform-init.{py,sh}`**: dieselben Silver-Transforms sind als Bootstrap dupliziert und hatten denselben Bug → identisch mitgefixt.

## Nicht geändert

- ODC-Contracts (`hr.v1.org-unit.state.odcontract.yaml`, `hr.v1.org-unit.changed.odcontract.yaml`) — unverändert korrekt, der Bug lag ausschliesslich im Silver-Transform.
- Kein Java-/Adapter-/Messaging-Code betroffen.
- Dokumentation in `README.md`/`specs/arc42.md` verwendet `OrgUnitState`/`EmployeeState` als Klassennamen, nicht als `eventtype`-Literale → absichtlich nicht angefasst.

## Test plan

- [ ] Nach Re-Deploy / SQLMesh-Run: `SELECT count(*) FROM iceberg.hr_silver.org_unit;` → > 0 (erwartet: 14)
- [ ] `SELECT count(*) FROM iceberg.analytics.org_hierarchy;` → > 0
- [ ] Soda-Check `hr_silver.org_unit is not empty` grün
- [ ] Soda-Check `analytics.org_hierarchy is not empty` grün
- [ ] `hr_silver.employee` weiterhin grün (kein Regressionen durch den zusätzlichen Filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)