### PR TITLE
fix(claims): emit events for IN_REVIEW and REJECTED transitions

### DIFF
--- a/claims/data-product/debezium/iceberg-sinks/iceberg-sink-claims-claims-rejected.json
+++ b/claims/data-product/debezium/iceberg-sinks/iceberg-sink-claims-claims-rejected.json
@@ -1,0 +1,29 @@
+{
+  "name": "iceberg-sink-claims-claims-rejected",
+  "config": {
+    "connector.class": "org.apache.iceberg.connect.IcebergSinkConnector",
+    "tasks.max": "1",
+    "topics": "claims.v1.rejected",
+    "iceberg.catalog.type": "nessie",
+    "iceberg.catalog.uri": "http://nessie:19120/api/v2",
+    "iceberg.catalog.ref": "main",
+    "iceberg.catalog.warehouse": "s3://warehouse/",
+    "iceberg.catalog.s3.endpoint": "http://minio:9000",
+    "iceberg.catalog.s3.access-key-id": "minioadmin",
+    "iceberg.catalog.s3.secret-access-key": "minioadmin",
+    "iceberg.catalog.s3.path-style-access": "true",
+    "iceberg.catalog.io-impl": "org.apache.iceberg.aws.s3.S3FileIO",
+    "iceberg.catalog.s3.region": "us-east-1",
+    "iceberg.tables": "claims_raw.claims_events",
+    "iceberg.tables.auto-create-enabled": "true",
+    "iceberg.tables.evolve-schema-enabled": "true",
+    "iceberg.control.topic": "control-iceberg-claims-claims-rejected",
+    "iceberg.control.commit.interval-ms": "10000",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": "false",
+    "consumer.auto.offset.reset": "earliest",
+    "consumer.session.timeout.ms": "60000",
+    "consumer.heartbeat.interval.ms": "10000"
+  }
+}

--- a/claims/data-product/debezium/iceberg-sinks/iceberg-sink-claims-claims-under-review.json
+++ b/claims/data-product/debezium/iceberg-sinks/iceberg-sink-claims-claims-under-review.json
@@ -1,0 +1,29 @@
+{
+  "name": "iceberg-sink-claims-claims-under-review",
+  "config": {
+    "connector.class": "org.apache.iceberg.connect.IcebergSinkConnector",
+    "tasks.max": "1",
+    "topics": "claims.v1.under-review",
+    "iceberg.catalog.type": "nessie",
+    "iceberg.catalog.uri": "http://nessie:19120/api/v2",
+    "iceberg.catalog.ref": "main",
+    "iceberg.catalog.warehouse": "s3://warehouse/",
+    "iceberg.catalog.s3.endpoint": "http://minio:9000",
+    "iceberg.catalog.s3.access-key-id": "minioadmin",
+    "iceberg.catalog.s3.secret-access-key": "minioadmin",
+    "iceberg.catalog.s3.path-style-access": "true",
+    "iceberg.catalog.io-impl": "org.apache.iceberg.aws.s3.S3FileIO",
+    "iceberg.catalog.s3.region": "us-east-1",
+    "iceberg.tables": "claims_raw.claims_events",
+    "iceberg.tables.auto-create-enabled": "true",
+    "iceberg.tables.evolve-schema-enabled": "true",
+    "iceberg.control.topic": "control-iceberg-claims-claims-under-review",
+    "iceberg.control.commit.interval-ms": "10000",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": "false",
+    "consumer.auto.offset.reset": "earliest",
+    "consumer.session.timeout.ms": "60000",
+    "consumer.heartbeat.interval.ms": "10000"
+  }
+}

--- a/claims/data-product/sqlmesh/silver/claim.sql
+++ b/claims/data-product/sqlmesh/silver/claim.sql
@@ -14,7 +14,7 @@ MODEL (
         )
     ),
     cron '@hourly',
-    description 'Current state of every claim. Derived from ClaimOpened/ClaimSettled events.'
+    description 'Current state of every claim. Derived from ClaimOpened/ClaimUnderReview/ClaimSettled/ClaimRejected events.'
 );
 
 WITH ranked AS (
@@ -32,7 +32,7 @@ WITH ranked AS (
             ORDER BY from_iso8601_timestamp(timestamp) DESC
         )                                     AS rn
     FROM iceberg.claims_raw.claims_events
-    WHERE eventtype IN ('ClaimOpened', 'ClaimSettled')
+    WHERE eventtype IN ('ClaimOpened', 'ClaimUnderReview', 'ClaimSettled', 'ClaimRejected')
       AND claimid IS NOT NULL
       AND from_iso8601_timestamp(timestamp) BETWEEN @start_date AND @end_date
 ),

--- a/claims/src/main/java/ch/yuno/claims/application/ClaimApplicationService.java
+++ b/claims/src/main/java/ch/yuno/claims/application/ClaimApplicationService.java
@@ -62,12 +62,16 @@ public class ClaimApplicationService implements ClaimCommandUseCase, ClaimQueryU
 
     /**
      * Start review of an open claim. Transitions OPEN → IN_REVIEW.
+     * Publishes claims.v1.under-review via the outbox.
      */
     @RolesAllowed({"CLAIMS_AGENT"})
     public Claim startReview(ClaimId claimId) {
         Claim claim = findOrThrow(claimId);
         claim.startReview();
         claimRepository.save(claim);
+
+        claimEventPublisher.claimUnderReview(claim);
+
         return claim;
     }
 
@@ -88,12 +92,16 @@ public class ClaimApplicationService implements ClaimCommandUseCase, ClaimQueryU
 
     /**
      * Reject a claim (OPEN or IN_REVIEW → REJECTED).
+     * Publishes claims.v1.rejected via the outbox.
      */
     @RolesAllowed({"CLAIMS_AGENT"})
     public Claim reject(ClaimId claimId) {
         Claim claim = findOrThrow(claimId);
         claim.reject();
         claimRepository.save(claim);
+
+        claimEventPublisher.claimRejected(claim);
+
         return claim;
     }
 

--- a/claims/src/main/java/ch/yuno/claims/domain/port/out/ClaimEventPublisher.java
+++ b/claims/src/main/java/ch/yuno/claims/domain/port/out/ClaimEventPublisher.java
@@ -1,0 +1,10 @@
+package ch.yuno.claims.domain.port.out;
+
+import ch.yuno.claims.domain.model.Claim;
+
+public interface ClaimEventPublisher {
+    void claimOpened(Claim claim);
+    void claimUnderReview(Claim claim);
+    void claimSettled(Claim claim);
+    void claimRejected(Claim claim);
+}

--- a/claims/src/main/java/ch/yuno/claims/infrastructure/messaging/ClaimEventPublisherAdapter.java
+++ b/claims/src/main/java/ch/yuno/claims/infrastructure/messaging/ClaimEventPublisherAdapter.java
@@ -30,10 +30,26 @@ public class ClaimEventPublisherAdapter implements ClaimEventPublisher {
     }
 
     @Override
+    public void claimUnderReview(Claim claim) {
+        outboxRepository.save(new OutboxEvent(
+                UUID.randomUUID(), "claims", claim.getClaimId().value(), "ClaimUnderReview",
+                ClaimsEventPayloadBuilder.TOPIC_CLAIM_UNDER_REVIEW,
+                ClaimsEventPayloadBuilder.buildClaimUnderReview(claim)));
+    }
+
+    @Override
     public void claimSettled(Claim claim) {
         outboxRepository.save(new OutboxEvent(
                 UUID.randomUUID(), "claims", claim.getClaimId().value(), "ClaimSettled",
                 ClaimsEventPayloadBuilder.TOPIC_CLAIM_SETTLED,
                 ClaimsEventPayloadBuilder.buildClaimSettled(claim)));
+    }
+
+    @Override
+    public void claimRejected(Claim claim) {
+        outboxRepository.save(new OutboxEvent(
+                UUID.randomUUID(), "claims", claim.getClaimId().value(), "ClaimRejected",
+                ClaimsEventPayloadBuilder.TOPIC_CLAIM_REJECTED,
+                ClaimsEventPayloadBuilder.buildClaimRejected(claim)));
     }
 }

--- a/claims/src/main/java/ch/yuno/claims/infrastructure/messaging/ClaimsEventPayloadBuilder.java
+++ b/claims/src/main/java/ch/yuno/claims/infrastructure/messaging/ClaimsEventPayloadBuilder.java
@@ -11,8 +11,10 @@ import java.util.UUID;
  */
 public final class ClaimsEventPayloadBuilder {
 
-    public static final String TOPIC_CLAIM_OPENED  = "claims.v1.opened";
-    public static final String TOPIC_CLAIM_SETTLED = "claims.v1.settled";
+    public static final String TOPIC_CLAIM_OPENED       = "claims.v1.opened";
+    public static final String TOPIC_CLAIM_UNDER_REVIEW = "claims.v1.under-review";
+    public static final String TOPIC_CLAIM_SETTLED      = "claims.v1.settled";
+    public static final String TOPIC_CLAIM_REJECTED     = "claims.v1.rejected";
 
     private ClaimsEventPayloadBuilder() {}
 
@@ -31,9 +33,37 @@ public final class ClaimsEventPayloadBuilder {
                 );
     }
 
+    public static String buildClaimUnderReview(Claim claim) {
+        return """
+                {"eventId":"%s","eventType":"ClaimUnderReview","claimId":"%s","claimNumber":"%s","policyId":"%s","claimDate":"%s","status":"%s","timestamp":"%s"}"""
+                .formatted(
+                        UUID.randomUUID(),
+                        claim.getClaimId(),
+                        claim.getClaimNumber(),
+                        claim.getPolicyId(),
+                        claim.getClaimDate(),
+                        claim.getStatus().name(),
+                        OffsetDateTime.now()
+                );
+    }
+
     public static String buildClaimSettled(Claim claim) {
         return """
                 {"eventId":"%s","eventType":"ClaimSettled","claimId":"%s","claimNumber":"%s","policyId":"%s","claimDate":"%s","status":"%s","timestamp":"%s"}"""
+                .formatted(
+                        UUID.randomUUID(),
+                        claim.getClaimId(),
+                        claim.getClaimNumber(),
+                        claim.getPolicyId(),
+                        claim.getClaimDate(),
+                        claim.getStatus().name(),
+                        OffsetDateTime.now()
+                );
+    }
+
+    public static String buildClaimRejected(Claim claim) {
+        return """
+                {"eventId":"%s","eventType":"ClaimRejected","claimId":"%s","claimNumber":"%s","policyId":"%s","claimDate":"%s","status":"%s","timestamp":"%s"}"""
                 .formatted(
                         UUID.randomUUID(),
                         claim.getClaimId(),

--- a/claims/src/main/resources/contracts/claims.v1.rejected.odcontract.yaml
+++ b/claims/src/main/resources/contracts/claims.v1.rejected.odcontract.yaml
@@ -1,0 +1,111 @@
+apiVersion: v2.3.0
+kind: DataContract
+id: claims-rejected-v1
+version: 1.0.0
+
+info:
+  title: Claim Rejected Event
+  description: Published when a claim is rejected (from OPEN or IN_REVIEW)
+  owner: claims-team@insurance.example.com
+  domain: claims
+  tags: ["claims", "lifecycle", "core"]
+  contact:
+    email: claims-team@insurance.example.com
+  sla:
+    freshness: "< 5 minutes"
+    availability: "99.9%"
+    qualityScore: 0.95
+
+servers:
+  production:
+    type: kafka
+    host: kafka.insurance.internal:9092
+    topic: claims.v1.rejected
+  development:
+    type: kafka
+    host: localhost:9092
+    topic: claims.v1.rejected
+
+schema:
+  type: json
+  specification: |
+    {
+      "type": "record",
+      "name": "ClaimRejected",
+      "namespace": "ch.yuno.claims.events",
+      "fields": [
+        {
+          "name": "eventId",
+          "type": "string",
+          "doc": "Unique event identifier (UUID)"
+        },
+        {
+          "name": "eventType",
+          "type": "string",
+          "doc": "Event type (ClaimRejected)"
+        },
+        {
+          "name": "claimId",
+          "type": "string",
+          "doc": "Unique claim identifier (UUID)"
+        },
+        {
+          "name": "policyId",
+          "type": "string",
+          "doc": "Policy identifier the claim was filed against"
+        },
+        {
+          "name": "claimNumber",
+          "type": "string",
+          "doc": "Human-readable claim number"
+        },
+        {
+          "name": "claimDate",
+          "type": "string",
+          "doc": "ISO 8601 date when the damage occurred"
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "doc": "Claim status at event time (REJECTED)"
+        },
+        {
+          "name": "timestamp",
+          "type": "string",
+          "doc": "ISO 8601 timestamp when event was created"
+        }
+      ]
+    }
+
+quality:
+  type: SodaCL
+  specification: |
+    checks for claims.v1.rejected:
+      - missing_count(claimId) = 0
+      - missing_count(eventId) = 0
+      - missing_count(policyId) = 0
+      - duplicate_count(eventId) = 0
+
+serviceLevel:
+  availability: "99.9%"
+  retention: "7 years"
+  latency: "< 500ms p99"
+  throughput: "200 events/sec"
+  backupRecovery: "24 hours RTO"
+
+dataProduct:
+  accessPatterns:
+    - type: kafka-consumer
+      description: "Subscribe to the topic for real-time event processing"
+      protocol: kafka
+      config:
+        bootstrap.servers: "${KAFKA_BOOTSTRAP_SERVERS}"
+        group.id: "${CONSUMER_GROUP_ID}"
+        auto.offset.reset: earliest
+        key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
+changelog:
+  - version: "1.0.0"
+    date: "2026-04-18"
+    description: "Initial version - Claim rejected"

--- a/claims/src/main/resources/contracts/claims.v1.under-review.odcontract.yaml
+++ b/claims/src/main/resources/contracts/claims.v1.under-review.odcontract.yaml
@@ -1,0 +1,111 @@
+apiVersion: v2.3.0
+kind: DataContract
+id: claims-under-review-v1
+version: 1.0.0
+
+info:
+  title: Claim Under Review Event
+  description: Published when a claim transitions from OPEN to IN_REVIEW
+  owner: claims-team@insurance.example.com
+  domain: claims
+  tags: ["claims", "lifecycle", "core"]
+  contact:
+    email: claims-team@insurance.example.com
+  sla:
+    freshness: "< 5 minutes"
+    availability: "99.9%"
+    qualityScore: 0.95
+
+servers:
+  production:
+    type: kafka
+    host: kafka.insurance.internal:9092
+    topic: claims.v1.under-review
+  development:
+    type: kafka
+    host: localhost:9092
+    topic: claims.v1.under-review
+
+schema:
+  type: json
+  specification: |
+    {
+      "type": "record",
+      "name": "ClaimUnderReview",
+      "namespace": "ch.yuno.claims.events",
+      "fields": [
+        {
+          "name": "eventId",
+          "type": "string",
+          "doc": "Unique event identifier (UUID)"
+        },
+        {
+          "name": "eventType",
+          "type": "string",
+          "doc": "Event type (ClaimUnderReview)"
+        },
+        {
+          "name": "claimId",
+          "type": "string",
+          "doc": "Unique claim identifier (UUID)"
+        },
+        {
+          "name": "policyId",
+          "type": "string",
+          "doc": "Policy identifier the claim is filed against"
+        },
+        {
+          "name": "claimNumber",
+          "type": "string",
+          "doc": "Human-readable claim number"
+        },
+        {
+          "name": "claimDate",
+          "type": "string",
+          "doc": "ISO 8601 date when the damage occurred"
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "doc": "Claim status at event time (IN_REVIEW)"
+        },
+        {
+          "name": "timestamp",
+          "type": "string",
+          "doc": "ISO 8601 timestamp when event was created"
+        }
+      ]
+    }
+
+quality:
+  type: SodaCL
+  specification: |
+    checks for claims.v1.under-review:
+      - missing_count(claimId) = 0
+      - missing_count(eventId) = 0
+      - missing_count(policyId) = 0
+      - duplicate_count(eventId) = 0
+
+serviceLevel:
+  availability: "99.9%"
+  retention: "7 years"
+  latency: "< 500ms p99"
+  throughput: "300 events/sec"
+  backupRecovery: "24 hours RTO"
+
+dataProduct:
+  accessPatterns:
+    - type: kafka-consumer
+      description: "Subscribe to the topic for real-time event processing"
+      protocol: kafka
+      config:
+        bootstrap.servers: "${KAFKA_BOOTSTRAP_SERVERS}"
+        group.id: "${CONSUMER_GROUP_ID}"
+        auto.offset.reset: earliest
+        key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
+changelog:
+  - version: "1.0.0"
+    date: "2026-04-18"
+    description: "Initial version - Claim moved to IN_REVIEW"

--- a/claims/src/test/java/ch/yuno/claims/application/ClaimApplicationServiceTest.java
+++ b/claims/src/test/java/ch/yuno/claims/application/ClaimApplicationServiceTest.java
@@ -67,6 +67,18 @@ class ClaimApplicationServiceTest {
     }
 
     @Test
+    void startReviewPublishesUnderReviewEvent() {
+        Claim claim = Claim.openNew("policy-1", "Damage", LocalDate.now());
+        when(claimRepository.findById(claim.getClaimId())).thenReturn(Optional.of(claim));
+        when(claimRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.startReview(claim.getClaimId());
+
+        assertEquals(ClaimStatus.IN_REVIEW, claim.getStatus());
+        verify(claimEventPublisher).claimUnderReview(any(Claim.class));
+    }
+
+    @Test
     void settleClaimPublishesSettledEvent() {
         Claim claim = Claim.openNew("policy-1", "Damage", LocalDate.now());
         claim.startReview();
@@ -79,7 +91,7 @@ class ClaimApplicationServiceTest {
     }
 
     @Test
-    void rejectClaimNoOutboxEvent() {
+    void rejectClaimPublishesRejectedEvent() {
         Claim claim = Claim.openNew("policy-1", "Damage", LocalDate.now());
         when(claimRepository.findById(claim.getClaimId())).thenReturn(Optional.of(claim));
         when(claimRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
@@ -87,7 +99,7 @@ class ClaimApplicationServiceTest {
         service.reject(claim.getClaimId());
 
         assertEquals(ClaimStatus.REJECTED, claim.getStatus());
-        verifyNoInteractions(claimEventPublisher);
+        verify(claimEventPublisher).claimRejected(any(Claim.class));
     }
 
     @Test

--- a/claims/src/test/java/ch/yuno/claims/infrastructure/messaging/ClaimsEventPayloadBuilderTest.java
+++ b/claims/src/test/java/ch/yuno/claims/infrastructure/messaging/ClaimsEventPayloadBuilderTest.java
@@ -1,0 +1,39 @@
+package ch.yuno.claims.infrastructure.messaging;
+
+import ch.yuno.claims.domain.model.Claim;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClaimsEventPayloadBuilderTest {
+
+    @Test
+    void buildClaimUnderReviewContainsExpectedFields() {
+        Claim claim = Claim.openNew("policy-1", "Damage", LocalDate.of(2026, 4, 18));
+        claim.startReview();
+
+        String json = ClaimsEventPayloadBuilder.buildClaimUnderReview(claim);
+
+        assertTrue(json.contains("\"eventType\":\"ClaimUnderReview\""));
+        assertTrue(json.contains("\"status\":\"IN_REVIEW\""));
+        assertTrue(json.contains("\"claimId\":\"" + claim.getClaimId() + "\""));
+        assertTrue(json.contains("\"claimNumber\":\"" + claim.getClaimNumber() + "\""));
+        assertTrue(json.contains("\"policyId\":\"policy-1\""));
+        assertTrue(json.contains("\"claimDate\":\"2026-04-18\""));
+    }
+
+    @Test
+    void buildClaimRejectedContainsExpectedFields() {
+        Claim claim = Claim.openNew("policy-1", "Damage", LocalDate.of(2026, 4, 18));
+        claim.reject();
+
+        String json = ClaimsEventPayloadBuilder.buildClaimRejected(claim);
+
+        assertTrue(json.contains("\"eventType\":\"ClaimRejected\""));
+        assertTrue(json.contains("\"status\":\"REJECTED\""));
+        assertTrue(json.contains("\"claimId\":\"" + claim.getClaimId() + "\""));
+        assertTrue(json.contains("\"policyId\":\"policy-1\""));
+    }
+}


### PR DESCRIPTION
Closes #18

## Summary
- Claims service now publishes `claims.v1.under-review` and `claims.v1.rejected` via the Transactional Outbox when `startReview()` / `reject()` fire. Previously these transitions were silently persisted with no mesh emission, so `claims_silver.claim` (and the dashboard) only ever saw `OPEN` / `SETTLED`.
- New ODC data contracts for both topics under `claims/src/main/resources/contracts/`.
- One Iceberg sink JSON per new topic (per ADR / task #14 split-one-sink-per-topic) — both write into `claims_raw.claims_events`; `scripts/reset-iceberg-sinks.sh` picks them up via glob automatically.
- `claims_silver.claim` eventtype filter extended to include `ClaimUnderReview` and `ClaimRejected`.

## Approach (A vs B from the issue)
Chose **(A) explicit domain events per transition** — matches the outbox/event-style used across `policy`, `billing`, `partner`. Snapshot-topic style (hr-system) wasn't adopted here because claims uses the Outbox pattern end-to-end; adding explicit events keeps downstream consumers (e.g. billing payout on `claims.v1.settled`) unchanged.

## Notes
- Domain layer remains framework-free (new methods only added to the pure-Java `ClaimEventPublisher` port).
- No seed-script change needed: `scripts/seed-test-data.sh` already calls `/review` / `/settle` / `/reject`; the new topics populate naturally on next seed run.
- Operational follow-up after deploy: re-seed (or replay transitions), then verify `SELECT status, count(*) FROM iceberg.claims_silver.claim GROUP BY 1` returns all four states.
- `ClaimEventPublisher.java` added to `claims` port/out with `git add -f` because `.gitignore` rule `out/` (IntelliJ build dir) inadvertently ignores DDD `port/out/` paths. This is a pre-existing, repo-wide latent issue (27 untracked port/out files across domains) and is **not** addressed here — left scoped to this PR's single file.

## Test plan
- [x] Unit tests green: `mvn -pl claims test -DexcludedGroups=playwright` (26 tests, new `ClaimsEventPayloadBuilderTest` + updated `ClaimApplicationServiceTest`)
- [ ] Deploy + re-seed on compose, then `SELECT status, count(*) FROM iceberg.claims_silver.claim GROUP BY 1` shows `SETTLED 3, IN_REVIEW 2, OPEN 2, REJECTED 1`
- [ ] "Schäden nach Status" pie chart in Superset shows all four states

🤖 Generated with [Claude Code](https://claude.com/claude-code)