### PR TITLE
fix(infra): prevent Superset financial chart dashboard hang

### DIFF
--- a/infra/superset/superset-init.sh
+++ b/infra/superset/superset-init.sh
@@ -159,6 +159,25 @@ FROM iceberg.product_silver.product""",
 
     db.session.commit()
 
+    # ── 2b. Sync dataset columns from Trino BEFORE chart creation ────────────
+    # Column metadata must be present before charts reference the dataset —
+    # otherwise dashboard-embedded charts with SUM/aggregate metrics can hang
+    # waiting on columns that were not yet introspected at chart-commit time.
+    # Additionally, every chart uses time_range="No filter" and include_time=False,
+    # so we explicitly disable temporal semantics on all datasets to prevent
+    # Superset from auto-binding the first TIMESTAMP column as main_dttm_col
+    # and applying implicit dashboard-level time filters.
+    for ds in datasets.values():
+        try:
+            ds.fetch_metadata()
+            ds.main_dttm_col = None
+            for col in ds.columns:
+                col.is_dttm = False
+            print(f"  Synced columns for '{ds.table_name}' ({len(ds.columns)} cols, dttm disabled)")
+        except Exception as e:
+            print(f"  ⚠ Column sync failed for '{ds.table_name}': {e}")
+    db.session.commit()
+
     # ── 3. Charts ─────────────────────────────────────────────────────────────
     def count_metric():
         return {
@@ -288,6 +307,8 @@ FROM iceberg.product_silver.product""",
             "groupby": ["collection_status"],
             "row_limit": 100,
             "include_time": False,
+            "query_mode": "aggregate",
+            "adhoc_filters": [],
         },
     )
 
@@ -379,15 +400,6 @@ FROM iceberg.product_silver.product""",
         dash.published = True
         db.session.commit()
         print(f"Dashboard '{DASH_TITLE}' updated.")
-
-    # ── 5. Sync dataset columns from Trino ────────────────────────────────
-    for ds in datasets.values():
-        try:
-            ds.fetch_metadata()
-            print(f"  Synced columns for '{ds.table_name}' ({len(ds.columns)} cols)")
-        except Exception as e:
-            print(f"  ⚠ Column sync failed for '{ds.table_name}': {e}")
-    db.session.commit()
 
 PYEOF
 


### PR DESCRIPTION
Closes #29

## Root Cause

Der Chart `Finanzzusammenfassung (Gold)` (`slice_id=10`) hing im Dashboard `datamesh-overview` dauerhaft im Loading-Spinner, während er unter `/explore/?slice_id=10` korrekt in <200 ms rendert.

Die im Issue vermutete Primär-Ursache (`include_time: False` fehlt) trifft **nicht** zu — die Zeile war bereits gesetzt. Die funktionierenden Charts (`Claim Detail`, `Policy Detail`) haben dieselben Temporal-Spalten.

Tatsächlicher Root Cause: `fetch_metadata()` lief **nach** der Chart-/Dashboard-Erstellung. Für leichte Charts (nur `COUNT(*)`) liefert Trino trotzdem; für den Financial-Chart mit 3 `SUM()`-Metrics hing der Dashboard-Poll, bis die Column-Metadaten registriert waren. Zusätzlich setzt `fetch_metadata()` `main_dttm_col` auto auf die erste `TIMESTAMP`-Spalte (`issued_at`), was im Dashboard-Kontext zu einem inkonsistenten Filter-Merge mit `include_time: False` führt.

## Fix

1. **Metadata-Sync vor Chart-Creation**: Neue Section 2b ruft `fetch_metadata()` auf allen Datasets auf, bevor die Charts sie referenzieren.
2. **Explizit non-temporal**: `main_dttm_col = None` und `is_dttm = False` auf allen Columns aller Datasets — da alle Charts ohnehin `time_range="No filter"` und `include_time: False` nutzen.
3. **Defensive chart-params**: `query_mode: "aggregate"` und `adhoc_filters: []` auf `chart_financial`.
4. Alte (obsolete) Section 5 am Ende entfernt.

## Scope

Nur `infra/superset/superset-init.sh`. Keine Services, ODCs, SQLMesh-Modelle, Kafka-Topics oder Debezium-Sinks betroffen.

## Test Plan

`superset-init.sh` ist via Read-Only-Volume-Mount gebunden (`docker-compose.yaml:1023`), kein Image-Rebuild nötig.

- [ ] `podman compose restart superset-init superset` → `superset-init` läuft grün durch (Logs zeigen `Synced columns for '<ds>' (<n> cols, dttm disabled)` für alle 8 Datasets)
- [ ] Dashboard `http://localhost:8088/superset/dashboard/datamesh-overview/` laden: `Finanzzusammenfassung (Gold)` rendert binnen <5 s, zeigt 2 Zeilen (PENDING 12.5k CHF, AT_RISK 1.68k CHF)
- [ ] Alle 9 übrigen Charts laden weiterhin korrekt ohne Regression
- [ ] Standalone `http://localhost:8088/explore/?slice_id=10` lädt unverändert in <200 ms
- [ ] `superset-init.sh` zweimal hintereinander laufen lassen → keine Fehler, idempotent

## Hinweis zur Persistenz

Falls Superset auf Persistent-Volume-DB läuft und der Chart/das Dataset bereits einen hängenden Metadata-State hat, ist ggf. ein einmaliger Reset des Superset-Metadata-Stores oder manuelle Neu-Provisionierung des betroffenen Datasets nötig, damit der Fix greift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)